### PR TITLE
(DO NOT MERGE) updated top10addons to enforce 10 unique addon names

### DIFF
--- a/usage_report/utils/top10addons.py
+++ b/usage_report/utils/top10addons.py
@@ -67,6 +67,11 @@ def top_10_addons_on_date(data, date, topN, period=7, country_list=None):
         .distinct()\
         .groupBy('country', 'addon_id')\
         .agg(F.count('*').alias('number_of_users'), F.last('name').alias('name'))\
+        .select('*', F.row_number().over(Window.partitionBy('country', 'name')
+                                         .orderBy(desc('number_of_users'))
+                                         .rowsBetween(Window.unboundedPreceding, Window.currentRow))
+                                   .alias('same_addon_rank'))\
+        .filter(col('same_addon_rank') == 1)\
         .select('*', lit(date).alias('submission_date_s3'),
                 lit(begin).alias('start_date'),
                 F.row_number().over(Window.partitionBy('country')


### PR DESCRIPTION
made the following changes for top10addons due to https://github.com/mozilla/Fx_Usage_Report/issues/51:

* for each addon (combination of `addon.id` and `addon.name`) per `addon.name`, keep only the most common one and get rid of the others. 
* get the top N addons from this filtered set, to ensure we have no `addon.name` collisions in our final data. 